### PR TITLE
Fix ping/pong for SocketCluster v3.0.0 up

### DIFF
--- a/golang/socketclusterclient/client.go
+++ b/golang/socketclusterclient/client.go
@@ -240,7 +240,7 @@ func (c *Client) recieve() (*Event, error) {
 	var message string
 	websocket.Message.Receive(c.ws, &message)
 
-	if message == "1" {
+	if message == "1" || message == "#1" {
 		Info.Println("PING")
 		c.pong()
 		return makeEmptyEvent(), nil


### PR DESCRIPTION
The ping/pong message is changed from v3.0.0 (22 November 2015). I didn't replace it with "#1" for compatible with older version (both of them are potentially conflict with user logic LOL).

// Ping and pong are now represented as raw messages '#1' and '#2' instead of '1' and '2' - This is to avoid potential conflicts with user logic when using the raw socket.send(...) method. //
